### PR TITLE
Add Linux/OSX support for affinewarp.m

### DIFF
--- a/+csmu/affinewarp.m
+++ b/+csmu/affinewarp.m
@@ -148,11 +148,19 @@ numelB = prod(RB.ImageSize);
 minChunkSz = 1e8;
 if numelB > minChunkSz
    L.debug('numelB (%.5e) over threshold (%.5e)', numelB, minChunkSz);
-   [~, sv] = memory;
-   avalailableMem = sv.PhysicalMemory.Available;
-   L.debug('Avalible Memory: %.1f GB', avalailableMem / 1E9);
+   os = computer;
+   if os == 'PCWIN64' % windows
+     [~, sv] = memory;
+     availableMem = sv.PhysicalMemory.Available;
+   elseif os == 'GLNXA64' % linux
+     [~, sv] = system('free -b | grep "^Mem" | tr -s " " | cut -d " " -f4 ');
+     availableMem = str2double(sv);
+   else % osx
+     availableMem = 8000000000; % presume 8GB
+   end
+   L.debug('Availible Memory: %.1f GB', availableMem / 1E9);
    heuristic = 10 * 32; % was 15
-   chunkSz = avalailableMem / heuristic;
+   chunkSz = availableMem / heuristic;
    threshChunkSz = chunkSz * 5;
    L.debug('Threshold chunk size = %.5e', threshChunkSz);
    doIter = numelB > threshChunkSz;


### PR DESCRIPTION
`memory` is a Windows only command. Getting free memory on OSX is obtuse, so it defaults to 8GB.